### PR TITLE
fix: typo na função de busca de OAs por parâmetros

### DIFF
--- a/src/main/kotlin/br/ufrn/imd/obama/oa/infrastructure/resource/ObjetoAprendizagemResourceImpl.kt
+++ b/src/main/kotlin/br/ufrn/imd/obama/oa/infrastructure/resource/ObjetoAprendizagemResourceImpl.kt
@@ -42,7 +42,7 @@ class ObjetoAprendizagemResourceImpl(
                 nome,
                 nivelEnsinoId,
                 temaConteudoId,
-                temaConteudoId,
+                descritorId,
                 habilidadeId,
                 tipoAcesso,
                 curriculo


### PR DESCRIPTION

**Por favor, informe se a PR segue os requisitos obrigatórios:**
<!--- Exemplo checkbox marcado: - [x] -->

- [x] Arquivos alterados/adicionados seguem o padrão _Camel Case_;
- [x] Integração com swagger funcionando;
- [ ] Testes das camadas repository, service e controller.

**Motivação para a criação da PR**
A busca por OAs pela BNCC não estava levando em conta o id do descritor passado por conta de um erro tipográfico(typo/erro de digitação)
<!---Descreva de maneira clara e concisa a motivação para a criação da PR na linha abaixo.-->


**O que foi feito**
O erro foi corrigido e a busca foi testada através do swagger. Por algum motivo os testes estão dando erro de compilação pra mim então não fui capaz de verifica-los.
<!---
  Se muita coisa foi feita, por favor resumir na linha abaixo.
  Exemplo:
    - Um açaí no capricho
    - Uma landing page
    - Um som que te faz dançar
-->

**Obs:** Se vocês estiverem conseguindo utilizar os testes recomendo testar essa branch e comparar os resultados com a main. Caso não, avisem aqui por favor.